### PR TITLE
0.1.3: A urgent fix

### DIFF
--- a/src/lib/router/helpers.ts
+++ b/src/lib/router/helpers.ts
@@ -37,7 +37,7 @@ export function parsePathHash(hash: string): ParsedPathHash {
     return { resources: [], params: {} };
   }
 
-  const hashParts = hash.split('#');
+  const hashParts = decodeURIComponent(hash).split('#');
   const lastPart = hashParts[hashParts.length - 1];
   const shouldParseParams = lastPart.includes('=') && !lastPart.includes('?');
   const keyValueRegexp = /(?:^|;)(?<key>[^=;]+)=(?<value>[^;]*)/g;


### PR DESCRIPTION
On mobile, the `#`  inside hashtag value would be url encoded to `%23`, we might use a different delimiter later