### PR TITLE
0.1.6: Change read path from `file` and `collection` to `read`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,7 @@ It can read docs organized in two ways:
 - React 19
 - Tailwind CSS 4
 
-## Self-hosting
-
-`readonly.page` is a static Single Page Application (SPA). You can host it
-anywhere that can serve static files. There is no backend and no database.
-
-### Run locally (development)
+## Development
 
 ```bash
 git clone git@github.com:hanlogy/web.readonly.page.git
@@ -49,6 +44,11 @@ cd web.readonly.page
 npm install
 npm run dev
 ```
+
+## Self-hosting
+
+`readonly.page` is a static Single Page Application (SPA). You can host it
+anywhere that can serve static files. There is no backend and no database.
 
 ### Build for production
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,8 +7,7 @@ function App() {
   return (
     <>
       <Route path="/" element={<HomePage />} />
-      <Route path="/file" element={<ReaderPage type="file" />} />
-      <Route path="/collection" element={<ReaderPage type="collection" />} />
+      <Route path="/read" element={<ReaderPage />} />
       <Route path="/resource-editor" element={<ResourceEditorPage />} />
     </>
   );

--- a/src/components/ResourceItem/ResourceItem.tsx
+++ b/src/components/ResourceItem/ResourceItem.tsx
@@ -15,7 +15,7 @@ export function ResourceItem({ resource }: { resource: Resource }) {
       <div className="absolute top-3 right-3">
         <Actions resource={resource} />
       </div>
-      <Link to={{ pathname: type, hash: `#${href}` }} className="contents">
+      <Link to={{ pathname: 'read', hash: `#${href}` }} className="contents">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gray-200 sm:h-12 sm:w-12">
           {type === 'collection' ? (
             <BookTextIcon />

--- a/src/components/ShareResourceDialog.tsx
+++ b/src/components/ShareResourceDialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { ClipboardCheckIcon, ClipboardIcon } from 'lucide-react';
+import { buildPathHash } from '@/lib/router/helpers';
 import {
   Button,
   clsx,
@@ -18,14 +19,15 @@ export function ShareResourceDialog({
     | { type: 'collection'; baseUrl: string; file: string };
 }) {
   const [copied, setCopied] = useState(false);
-  let hash: string[] = [];
+  //let hash: string[] = [];
+  let params: Record<string, string> = {};
 
   if (resource.type === 'collection') {
-    hash = [resource.baseUrl, resource.file];
+    params = { base: resource.baseUrl, file: resource.file };
   } else {
-    hash = [resource.url];
+    params = { url: resource.url };
   }
-  const url = `${window.location.origin}/${resource.type}#` + hash.join('#');
+  const url = `${window.location.origin}/read` + buildPathHash(params);
 
   return (
     <Dialog

--- a/src/pages/ReaderPage/ReaderPage.tsx
+++ b/src/pages/ReaderPage/ReaderPage.tsx
@@ -1,4 +1,3 @@
-import type { ResourceType } from '@/definitions/types';
 import { ensureUrlProtocol } from '@/helpers/ensureUrlProtocol';
 import { getExtensionFromUrl } from '@/helpers/getExtensionFromUrl';
 import { parsePathHash } from '@/lib/router/helpers';
@@ -6,7 +5,7 @@ import { usePath } from '@/lib/router/hooks';
 import { resolveWithBaseUrl } from '@/packages/ts-lib';
 import { PageView } from './ReaderView';
 
-export function ReaderPage({ type }: { type: ResourceType }) {
+export function ReaderPage() {
   const { hash } = usePath();
   const {
     file: fileParam,
@@ -16,11 +15,10 @@ export function ReaderPage({ type }: { type: ResourceType }) {
 
   const notFound = () => <>Page not found</>;
 
-  if (
-    (type !== 'collection' && type !== 'file') ||
-    (type === 'file' && !urlParam) ||
-    (type === 'collection' && (!baseParam || !fileParam))
-  ) {
+  const type =
+    baseParam && fileParam ? 'collection' : urlParam ? 'file' : undefined;
+
+  if (!type) {
     return notFound();
   }
 

--- a/src/pages/ReaderPage/ReaderView.tsx
+++ b/src/pages/ReaderPage/ReaderView.tsx
@@ -12,6 +12,7 @@ import {
   Page,
   useDialog,
 } from '@/packages/react-dom-lib';
+import { resolveWithBaseUrl } from '@/packages/ts-lib';
 import { createHttpClient } from '@/packages/ts-lib/http';
 import { MarkdownViewer } from './MarkdownViewer';
 import { Sidebar } from './Sidebar';
@@ -39,10 +40,12 @@ export function PageView({
 
   const linkHrefBuilder = useCallback(
     (ref: string) => {
-      return [
-        type,
-        type === 'file' ? ref : buildPathHash({ base: baseUrl, file: ref }),
-      ].join('');
+      const params =
+        type === 'collection'
+          ? { base: baseUrl, file: ref }
+          : { url: resolveWithBaseUrl({ base: baseUrl, ref }) };
+
+      return `read${buildPathHash(params)}`;
     },
     [baseUrl, type]
   );

--- a/src/pages/ReaderPage/Sidebar.tsx
+++ b/src/pages/ReaderPage/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { ChevronDownIcon, ChevronRightIcon } from 'lucide-react';
 import { parseSidebar } from '@/lib/markdown';
 import type { SidebarItem } from '@/lib/markdown/types';
-import { Link, usePath } from '@/lib/router';
+import { Link } from '@/lib/router';
 import { buildPathHash } from '@/lib/router/helpers';
 import { clsx, CollapsibleTree, IconButton } from '@/packages/react-dom-lib';
 
@@ -37,8 +37,6 @@ function SidebarButton({
   isCollapsed: boolean;
   baseUrl: string;
 }) {
-  const { pathname } = usePath();
-
   return (
     <div
       className={clsx('flex h-9 w-full items-center text-left text-gray-600')}
@@ -46,7 +44,7 @@ function SidebarButton({
       {item.link ? (
         <Link
           to={{
-            pathname,
+            pathname: 'read',
             hash: buildPathHash({ base: baseUrl, file: item.link }),
           }}
           className="flex-1 pl-2 text-gray-500 hover:text-gray-700"


### PR DESCRIPTION
Fixed: https://github.com/hanlogy/web.readonly.page/issues/7
Fixed: https://github.com/hanlogy/web.readonly.page/issues/8